### PR TITLE
Multi-tasking support for esp8266

### DIFF
--- a/Scheduler.h
+++ b/Scheduler.h
@@ -23,6 +23,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+//#define DEBUG_SCHEDULER 1
+
 class SchedulerClass {
 public:
   /**
@@ -106,6 +108,12 @@ protected:
   static const size_t DEFAULT_STACK_SIZE = 512;
   static const size_t STACK_MAX = 16384;
 
+#elif defined(ARDUINO_ARCH_ESP8266)
+
+  /** Default stack size and stack max. */
+  static const size_t DEFAULT_STACK_SIZE = 1024;
+  static const size_t STACK_MAX = 0x2000; // esp8266 Arduino reserves 4096bytes for the stack (heap starts 0x3FFF after the stack begin address)
+
 #else
 #error "Scheduler.h: board not supported"
 #endif
@@ -121,7 +129,9 @@ protected:
 };
 
 /** Scheduler single-ton. */
-extern SchedulerClass Scheduler;
+//extern SchedulerClass Scheduler;
+#define Scheduler sched()
+extern SchedulerClass& sched(void);
 
 /**
  * Syntactic sugar for scheduler based busy-wait for condition;

--- a/Scheduler.h
+++ b/Scheduler.h
@@ -25,6 +25,11 @@
 
 //#define DEBUG_SCHEDULER 1
 
+#if defined(ARDUINO_ARCH_ESP8266)
+extern "C" unsigned int get_clock();
+extern "C" void delay_until(uint32_t clock_ms);
+#endif
+
 class SchedulerClass {
 public:
   /**
@@ -111,8 +116,8 @@ protected:
 #elif defined(ARDUINO_ARCH_ESP8266)
 
   /** Default stack size and stack max. */
-  static const size_t DEFAULT_STACK_SIZE = 1024;
-  static const size_t STACK_MAX = 0x2000; // esp8266 Arduino reserves 4096bytes for the stack (heap starts 0x3FFF after the stack begin address)
+  static const size_t DEFAULT_STACK_SIZE = 512;
+  static const size_t STACK_MAX = 0x2000 + 0x4000; // esp8266 Arduino reserves 4096bytes for the stack (heap starts 0x3FFF after the stack begin address)
 
 #else
 #error "Scheduler.h: board not supported"

--- a/Scheduler.h
+++ b/Scheduler.h
@@ -59,8 +59,8 @@ public:
    * @return bool.
    */
   static bool start(func_t taskSetup,
-		    func_t taskLoop,
-		    size_t stackSize = DEFAULT_STACK_SIZE);
+            func_t taskLoop,
+            size_t stackSize = DEFAULT_STACK_SIZE);
 
   /**
    * Context switch to next task in run queue.

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Scheduler for simple multi-tasking.
 paragraph=This library is an implementation of an extended sub-set of Arduino Scheduler interface. The function yield() will context switch between multiple loop() functions.
 category=Other
 url=https://github.com/mikaelpatel/Arduino-Scheduler
-architectures=avr,sam,samd
+architectures=avr,sam,samd,esp8266


### PR DESCRIPTION
It requires integration with Arduino esp8266 runtime.

There are space for several tasks but we need to manage the heap end address that is statically assigned in the Arduino esp8266. I have tested it with several tasks without any issue. Note that a task is created to run `loop()` since we need to return the `loop_task()` to allow that the runtime of the esp8266 SDK runs.

Issues/Improvements:
- Scheduler.begin() need to be avoided if a task has been added  (not done)
- Avoid static initialization order fiasco by implementing `sched()` (done)
