### PR TITLE
Use template for callbacks

### DIFF
--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -19,43 +19,6 @@
 #include "Scheduler.h"
 #include <Arduino.h>
 
-// Configuration: SRAM and heap handling
-#if defined(TEENSYDUINO)
-#undef ARDUINO_ARCH_AVR
-#define TEENSY_ARCH_ARM
-#if defined(__MK20DX256__)
-#define RAMEND 0x20008000
-#elif defined(__MK64FX512__)
-#define RAMEND 0x20020000
-#elif defined(__MK66FX1M0__)
-#define RAMEND 0x20030000
-#endif
-
-#elif defined(ARDUINO_ARCH_AVR)
-extern int __heap_start, *__brkval;
-extern char* __malloc_heap_end;
-extern size_t __malloc_margin;
-
-#elif defined(ARDUINO_ARCH_SAM)
-#if !defined(RAMEND)
-#define RAMEND 0x20088000
-#endif
-
-#elif defined(ARDUINO_ARCH_SAMD)
-#if !defined(RAMEND)
-#define RAMEND 0x20008000
-#endif
-
-#elif defined(ARDUINO_ARCH_STM32F1)
-#if !defined(RAMEND)
-#define RAMEND 0x20005000
-#endif
-
-#endif
-
-// Stack magic pattern
-const uint8_t MAGIC = 0xa5;
-
 // Single-ton
 SchedulerClass Scheduler;
 
@@ -80,47 +43,6 @@ bool SchedulerClass::begin(size_t stackSize)
   return (true);
 }
 
-bool SchedulerClass::start(func_t taskSetup, func_t taskLoop, size_t stackSize)
-{
-  // Check called from main task and valid task loop function
-  if ((s_running != &s_main) || (taskLoop == NULL)) return (false);
-
-  // Adjust stack size with size of task context
-  stackSize += sizeof(task_t);
-
-  // Allocate stack(s) and check if main stack top should be set
-  size_t frame = RAMEND - (size_t) &frame;
-  uint8_t stack[s_top - frame];
-  if (s_main.stack == NULL) {
-    s_main.stack = stack;
-    memset(stack, MAGIC, s_top - frame);
-  }
-
-#if defined(ARDUINO_ARCH_AVR)
-  // Check that the task can be allocated
-  int HEAPEND = (__brkval == 0 ? (int) &__heap_start : (int) __brkval);
-  int STACKSTART = ((int) stack) - stackSize;
-  HEAPEND += __malloc_margin;
-  if (STACKSTART < HEAPEND) return (false);
-
-  // Adjust heap limit
-  __malloc_heap_end = (char*) STACKSTART;
-#else
-  // Check that the task can be allocated
-  if (s_top + stackSize > STACK_MAX) return (false);
-#endif
-
-  // Adjust stack top for next task allocation
-  s_top += stackSize;
-
-  // Fill stack with magic pattern to allow detect of stack usage
-  memset(stack - stackSize, MAGIC, stackSize - sizeof(task_t));
-
-  // Initiate task with given functions and stack top
-  init(taskSetup, taskLoop, stack - stackSize);
-  return (true);
-}
-
 void SchedulerClass::yield()
 {
   // Caller will continue here on yield
@@ -137,23 +59,6 @@ size_t SchedulerClass::stack()
   size_t bytes = 0;
   while (*sp++ == MAGIC) bytes++;
   return (bytes);
-}
-
-void SchedulerClass::init(func_t setup, func_t loop, const uint8_t* stack)
-{
-  // Add task last in run queue (main task)
-  task_t task;
-  task.next = &s_main;
-  task.prev = s_main.prev;
-  s_main.prev->next = &task;
-  s_main.prev = &task;
-  task.stack = stack;
-
-  // Create context for new task, caller will return
-  if (setjmp(task.context)) {
-    if (setup != NULL) setup();
-    while (1) loop();
-  }
 }
 
 extern "C"


### PR DESCRIPTION
Hello,

I changed the `start()` and `startLoop()` methods to take template-defined callbacks. AFAIK this is backward compatible with current API (e.g. my old code still works).

I did this to be able to call any kind of functor. For example, I use a lambda function to call a class instance's method.

Since your `task_t` class is totally separated from the infinite loop, this was very simple to do and it is possible to use both lambdas & plain, old functions at the same time!

Note: if we'd accept to call `taskSetup` before allocating the stack, the code would be even simpler; without breaking compatibility.

Thanks for your lib!
M.